### PR TITLE
fix(a11y): add aria-label to create task button

### DIFF
--- a/src/task/components/ongoing-tasks/OngoingTasks.tsx
+++ b/src/task/components/ongoing-tasks/OngoingTasks.tsx
@@ -37,6 +37,7 @@ export const OngoingTasks = () => {
             size="sm"
             className={styles.ongoingTasksBtnNew}
             to="/task-form"
+            aria-label="Create new task"
           >
             <PlusIcon />
           </ButtonLink>


### PR DESCRIPTION
Closes #7

## 📝 Description
Adds missing aria-label to the ongoing tasks header button to fix Lighthouse a11y error.

Fixes # (issue number)

## 🔄 Type of change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ♻️ Refactor (code improvement without adding new functionality)

## ✅ Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings