### PR TITLE
fix(demo): add CDN domains to CSP for mock images

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -37,7 +37,7 @@
       script-src 'self' 'unsafe-inline' https://accounts.google.com/gsi/client https://app.netlify.com;
       style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
       font-src 'self' https://fonts.gstatic.com;
-      img-src 'self' data: blob: https://task-app-ifmj.onrender.com https://*.googleusercontent.com;
+      img-src 'self' data: blob: https://task-app-ifmj.onrender.com https://*.googleusercontent.com https://cdn.jsdelivr.net https://api.dicebear.com;
       connect-src 'self' https://task-app-ifmj.onrender.com wss://task-app-ifmj.onrender.com https://accounts.google.com/gsi/;
       frame-src 'self' https://accounts.google.com https://app.netlify.com;
       object-src 'none';

--- a/src/tests/mocks/handlers/event.ts
+++ b/src/tests/mocks/handlers/event.ts
@@ -55,7 +55,8 @@ export const eventHandlers = [
       total: filteredEvents.length,
     }
 
-    return HttpResponse.json(response)
+    const cleanItems = response.events.map(({ task: _, ...evt }) => evt)
+    return HttpResponse.json({ ...response, events: cleanItems })
   }),
   /**
    * PUT /api/events/:id - Update event

--- a/src/tests/mocks/handlers/user.ts
+++ b/src/tests/mocks/handlers/user.ts
@@ -38,7 +38,7 @@ export const userHandlers = [
     }
 
     // Simulate upload success with fake URL
-    const fakeImageUrl = `https://api.dicebear.com/9.x/initials/svg?seed=${MOCK_LOGGED_USER.firstName}${MOCK_LOGGED_USER.lastName}`
+    const fakeImageUrl = `https://api.dicebear.com/9.x/initials/svg?backgroundColor=b6e3f4,c0aede,d1d4f9&seed=${MOCK_LOGGED_USER.firstName}${MOCK_LOGGED_USER.lastName}`
     MOCK_LOGGED_USER.profileImageURL = fakeImageUrl
 
     return HttpResponse.json({ profileImageURL: fakeImageUrl })


### PR DESCRIPTION
## 📝 Description
Add CDN domains to CSP for mock images:

- Add https://cdn.jsdelivr.net for Faker.js user avatars
- Add https://api.dicebear.com for DiceBear profile image generator
- Fixes CSP violations in demo environment with mock data

## 🔄 Type of change

**Production Code:**
- [ ] ✨ New feature (feat) - New feature for users
- [x] 🐛 Bug fix (fix) - Bug fix in production code
- [ ] ♻️ Refactor (refactor) - Code improvement without behavior change
- [ ] ⚡ Performance (perf) - Performance improvements

**Development & Infrastructure:**
- [ ] 🧪 Tests (test) - Adding/updating tests or test infrastructure
- [ ] 🔨 Build (build) - Changes to build system or dependencies
- [ ] 👷 CI/CD (ci) - Changes to CI/CD configuration
- [ ] 🔧 Chore (chore) - Maintenance tasks (deps update, tooling)

**Documentation & Style:**
- [ ] 📝 Documentation (docs) - Documentation only changes
- [ ] 💎 Style (style) - Code formatting (no logic change)

**Breaking Changes:**
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings