### PR TITLE
fix(demo): add CDN domains to connect-src for MSW passthrough

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -38,7 +38,7 @@
       style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
       font-src 'self' https://fonts.gstatic.com;
       img-src 'self' data: blob: https://task-app-ifmj.onrender.com https://*.googleusercontent.com https://cdn.jsdelivr.net https://api.dicebear.com;
-      connect-src 'self' https://task-app-ifmj.onrender.com wss://task-app-ifmj.onrender.com https://accounts.google.com/gsi/;
+      connect-src 'self' https://task-app-ifmj.onrender.com wss://task-app-ifmj.onrender.com https://accounts.google.com/gsi/ https://cdn.jsdelivr.net https://api.dicebear.com;
       frame-src 'self' https://accounts.google.com https://app.netlify.com;
       object-src 'none';
       base-uri 'self';


### PR DESCRIPTION
## 📝 Description
- Add https://cdn.jsdelivr.net to connect-src
- Add https://api.dicebear.com to connect-src
- Required for MSW Service Worker to passthrough image fetches
- Fixes CSP violations when loading Faker.js and DiceBear images in demo mode



Follow up #72

## 🔄 Type of change

**Production Code:**
- [ ] ✨ New feature (feat) - New feature for users
- [x] 🐛 Bug fix (fix) - Bug fix in production code
- [ ] ♻️ Refactor (refactor) - Code improvement without behavior change
- [ ] ⚡ Performance (perf) - Performance improvements

**Development & Infrastructure:**
- [ ] 🧪 Tests (test) - Adding/updating tests or test infrastructure
- [ ] 🔨 Build (build) - Changes to build system or dependencies
- [ ] 👷 CI/CD (ci) - Changes to CI/CD configuration
- [ ] 🔧 Chore (chore) - Maintenance tasks (deps update, tooling)

**Documentation & Style:**
- [ ] 📝 Documentation (docs) - Documentation only changes
- [ ] 💎 Style (style) - Code formatting (no logic change)

**Breaking Changes:**
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings